### PR TITLE
face-table: remove malloc/free

### DIFF
--- a/face-table.h
+++ b/face-table.h
@@ -26,6 +26,12 @@
 extern "C" {
 #endif
 
+#ifndef NDN_FACE_ENTRIES_NUMOF
+/**
+ * @brief Number of max. faces in the face table
+ */
+#define NDN_FACE_ENTRIES_NUMOF (10)
+#endif
 
 typedef struct _face_list_entry {
     kernel_pid_t id;  /**< ID of the incoming face */


### PR DESCRIPTION
Remove calls to `malloc()` and `free()` in the face-table by using
a static table with constant size. `NDN_FACE_ENTRIES_NUMOF` defines the
face-table size and is currently set to `10` entries by default.
`NDN_FACE_ENTRIES_NUMOF` can also be overwritten at compile-time with
CFLAGS+="-DNDN_FACE_ENTRIES_NUMOF=X".
