### PR TITLE
pit: use unused variable r

### DIFF
--- a/pit.c
+++ b/pit.c
@@ -103,6 +103,7 @@ int ndn_pit_add(kernel_pid_t face_id, int face_type, ndn_shared_block_t* si)
         ndn_block_t pn;
         int r = ndn_interest_get_name(&entry->shared_pi->block, &pn);
         assert(r == 0);
+        (void) r;
 
         if (0 == memcmp(pn.buf, name.buf,
                         (pn.len < name.len ? pn.len : name.len))) {


### PR DESCRIPTION
When compiling with `-Werror=unused-variable` (like it's the case for `RIOT`), then the compiler fails, because `r` is not used (assuming `asserts` are not compiled).

The (unnecessary) cast to `void` satisfies the compiler.
