### PR TITLE
Fix TLV-TYPE for InterestLifetime element

### DIFF
--- a/encoding/ndn-constants.h
+++ b/encoding/ndn-constants.h
@@ -34,7 +34,7 @@ enum {
     /* Interest-related TLVs */
     NDN_TLV_SELECTORS        = 9,
     NDN_TLV_NONCE            = 10,
-    NDN_TLV_INTERESTLIFETIME = 11,
+    NDN_TLV_INTERESTLIFETIME = 12,
 
     /* Data-related TLVs */
     NDN_TLV_METAINFO         = 20,


### PR DESCRIPTION
[According to the doc](https://named-data.net/doc/NDN-packet-spec/current/types.html#types), NDN_TLV_INTERESTLIFETIME should be 12, not 11.