### PR TITLE
fix type cast and printf format for RIOT CI

### DIFF
--- a/encoding/data.c
+++ b/encoding/data.c
@@ -895,7 +895,7 @@ int ndn_data_verify_signature(ndn_block_t* block,
         case NDN_SIG_TYPE_DIGEST_SHA256:
         {
             if (num != 32) {
-                DEBUG("ndn_encoding: invalid digest sig value length (%u)\n",
+                DEBUG("ndn_encoding: invalid digest sig value length (%"PRIu32")\n",
                       num);
                 return -1;
             }
@@ -912,7 +912,7 @@ int ndn_data_verify_signature(ndn_block_t* block,
         case NDN_SIG_TYPE_HMAC_SHA256:
         {
             if (num != 32) {
-                DEBUG("ndn_encoding: invalid hmac sig value length (%u)\n",
+                DEBUG("ndn_encoding: invalid hmac sig value length (%"PRIu32")\n",
                       num);
                 return -1;
             }
@@ -934,7 +934,7 @@ int ndn_data_verify_signature(ndn_block_t* block,
         case NDN_SIG_TYPE_ECDSA_SHA256:
         {
             if (num != 64) {
-                DEBUG("ndn_encoding: invalid ecdsa sig value length (%u)\n",
+                DEBUG("ndn_encoding: invalid ecdsa sig value length (%"PRIu32")\n",
                       num);
                 return -1;
             }
@@ -1004,7 +1004,7 @@ ndn_shared_block_t* ndn_data_decrypt_with_ccm(ndn_block_t* block,
     ndn_metainfo_t metainfo;
     l = ndn_metainfo_from_block(buf, len, &metainfo);
     if (metainfo.content_type != NDN_CONTENT_TYPE_CCM) {
-        DEBUG("ndn_encoding: wrong content type %d for ccm data\n",
+        DEBUG("ndn_encoding: wrong content type %"PRId32" for ccm data\n",
               metainfo.content_type);
         return NULL;
     }

--- a/ndn.c
+++ b/ndn.c
@@ -144,7 +144,7 @@ static void _process_packet(kernel_pid_t face_id, int face_type,
     if (buf[0] & NDN_L2_FRAG_HB_MASK) {
         uint16_t frag_id = (buf[1] << 8) + buf[2];
         DEBUG("ndn: l2 fragment received (MF=%x, SEQ=%u, ID=%02x, "
-              "packet size = %d, iface=%" PRIkernel_pid ")\n",
+              "packet size = %zu, iface=%" PRIkernel_pid ")\n",
               (buf[0] & NDN_L2_FRAG_MF_MASK) >> 5,
               buf[0] & NDN_L2_FRAG_SEQ_MASK,
               frag_id, pkt->size, face_id);

--- a/netif.h
+++ b/netif.h
@@ -33,7 +33,7 @@ extern "C" {
  */
 typedef struct ndn_netif {
     kernel_pid_t iface;  /**< pid of the interface */
-    uint16_t mtu;        /**< mtu of the interface */
+    int mtu;        /**< mtu of the interface */
 } ndn_netif_t;
 
 /**


### PR DESCRIPTION
Some compilers have more error messages than others.
Basically : 
 - `%d` becomes `%"PRId32"` when dealing with `int32_t`
 - `%u` becomes `%"PRIu32"` when dealing with `uint32_t`
 - `%d` becomes `%zu` when dealing with `size_t`

I also modified `ndn_netif::mtu` to `int` to avoid errors with signed and unsigned comparison.