### PR TITLE
adapt to moved kernel_pid_t location

### DIFF
--- a/app.h
+++ b/app.h
@@ -25,7 +25,7 @@
 
 #include <xtimer.h>
 #include <net/gnrc/pktbuf.h>
-#include "sched.h"
+#include <sched.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/app.h
+++ b/app.h
@@ -23,9 +23,9 @@
 #include "encoding/name.h"
 #include "forwarding-strategy.h"
 
-#include <kernel_types.h>
 #include <xtimer.h>
 #include <net/gnrc/pktbuf.h>
+#include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cs.h
+++ b/cs.h
@@ -22,7 +22,6 @@
 
 #include "encoding/shared-block.h"
 
-#include <kernel_types.h>
 //#include <xtimer.h>
 
 #ifdef __cplusplus

--- a/face-table.h
+++ b/face-table.h
@@ -20,7 +20,7 @@
 #ifndef NDN_FACE_TABLE_H_
 #define NDN_FACE_TABLE_H_
 
-#include "sched.h"
+#include <sched.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/face-table.h
+++ b/face-table.h
@@ -20,7 +20,7 @@
 #ifndef NDN_FACE_TABLE_H_
 #define NDN_FACE_TABLE_H_
 
-#include <kernel_types.h>
+#include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/fib.h
+++ b/fib.h
@@ -24,7 +24,7 @@
 #include "face-table.h"
 
 #include <xtimer.h>
-#include "sched.h"
+#include <sched.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/fib.h
+++ b/fib.h
@@ -23,8 +23,8 @@
 #include "encoding/shared-block.h"
 #include "face-table.h"
 
-#include <kernel_types.h>
 #include <xtimer.h>
+#include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/forwarding-strategy.h
+++ b/forwarding-strategy.h
@@ -22,7 +22,7 @@
 
 #include "encoding/shared-block.h"
 
-#include <kernel_types.h>
+#include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/forwarding-strategy.h
+++ b/forwarding-strategy.h
@@ -22,7 +22,7 @@
 
 #include "encoding/shared-block.h"
 
-#include "sched.h"
+#include <sched.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/l2.h
+++ b/l2.h
@@ -23,7 +23,7 @@
 #include "encoding/shared-block.h"
 
 #include <net/gnrc/pktbuf.h>
-#include "sched.h"
+#include <sched.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/l2.h
+++ b/l2.h
@@ -22,8 +22,8 @@
 
 #include "encoding/shared-block.h"
 
-#include <kernel_types.h>
 #include <net/gnrc/pktbuf.h>
+#include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/ndn.h
+++ b/ndn.h
@@ -20,7 +20,7 @@
 #ifndef NDN_H_
 #define NDN_H_
 
-#include <kernel_types.h>
+#include "sched.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/ndn.h
+++ b/ndn.h
@@ -20,7 +20,7 @@
 #ifndef NDN_H_
 #define NDN_H_
 
-#include "sched.h"
+#include <sched.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/netif.h
+++ b/netif.h
@@ -20,7 +20,7 @@
 #ifndef NDN_NETIF_H_
 #define NDN_NETIF_H_
 
-#include <kernel_types.h>
+#include "sched.h"
 
 #include "encoding/block.h"
 

--- a/netif.h
+++ b/netif.h
@@ -20,7 +20,7 @@
 #ifndef NDN_NETIF_H_
 #define NDN_NETIF_H_
 
-#include "sched.h"
+#include <sched.h>
 
 #include "encoding/block.h"
 

--- a/pit.h
+++ b/pit.h
@@ -23,7 +23,7 @@
 #include "encoding/shared-block.h"
 #include "face-table.h"
 
-#include "sched.h"
+#include <sched.h>
 #include <xtimer.h>
 
 #ifdef __cplusplus

--- a/pit.h
+++ b/pit.h
@@ -23,7 +23,7 @@
 #include "encoding/shared-block.h"
 #include "face-table.h"
 
-#include <kernel_types.h>
+#include "sched.h"
 #include <xtimer.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
RIOT will soon drop the used kernel_types.h header.
This PR updates ndn-riot to use the new location of the used kernel_pid_t.